### PR TITLE
Preserve `edited` property on conditions

### DIFF
--- a/lib/reports/ppl-conditions/parse.js
+++ b/lib/reports/ppl-conditions/parse.js
@@ -5,8 +5,7 @@ const getCondition = (condition, level, protocolTitle = '') => {
   return {
     level,
     protocol_name: protocolTitle,
-    ...condition,
-    edited: !!condition.edited
+    ...condition
   };
 };
 


### PR DESCRIPTION
This isn't a boolean flag as I believed, but the actual edited content of the condition.

This means that flattening it to a boolean deletes the entire condition.