### PR TITLE
Include schema version in PPL conditions report

### DIFF
--- a/lib/reports/ppl-conditions/parse.js
+++ b/lib/reports/ppl-conditions/parse.js
@@ -24,7 +24,7 @@ const parse = project => {
 
   const row = {
     establishment: project.name,
-    ...pick(project, 'licence_number', 'title', 'status'),
+    ...pick(project, 'licence_number', 'title', 'status', 'schema_version'),
     issue_date: moment(project.issue_date).format('YYYY-MM-DD'),
     conditions: project.data.conditions || [],
     protocols: (project.data.protocols || []).map(protocol => pick(protocol, ['title', 'conditions']))


### PR DESCRIPTION
This makes it easier to filter the report for legacy and new style projects.