### PR TITLE
Explicitly sort activity

### DIFF
--- a/lib/reports/ppl-sla/index.js
+++ b/lib/reports/ppl-sla/index.js
@@ -1,7 +1,8 @@
 const moment = require('moment-business-time');
-const { get } = require('lodash');
+const { get, sortBy } = require('lodash');
 
 module.exports = ({ db, query: params, flow }) => {
+
   const query = () => {
     return db.flow('cases')
       .leftJoin('activity_log', 'cases.id', 'activity_log.case_id')
@@ -19,11 +20,11 @@ module.exports = ({ db, query: params, flow }) => {
   const parse = record => {
 
     const getDeadlineState = () => {
-      const currentState = record.activity.reduce((state, activity) => {
+      const currentState = sortBy(record.activity, 'created_at', 'asc').reduce((state, activity) => {
         const status = flow[activity.event.status];
         state.extended = state.extended || get(activity, 'event.data.extended', false);
         const isSubmission = !state.withASRU && status.withASRU;
-        const isClosedOrReturned = state.withASRU && !status.withASRU;
+        const isClosedOrReturned = !status.open || (state.withASRU && !status.withASRU);
 
         const meta = get(activity, 'event.data.meta', {});
 


### PR DESCRIPTION
Activity logs were not being returned by the database query in a reliable order, so sort them explicitly before reducing.