### PR TITLE
Include null establishment ids in task query

### DIFF
--- a/lib/reports/tasks/index.js
+++ b/lib/reports/tasks/index.js
@@ -10,7 +10,7 @@ module.exports = ({ db, query: params, flow }) => {
         db.flow.raw('JSON_AGG(activity_log.event_name) as activity')
       ])
       .where({ status: 'resolved' })
-      .whereRaw(`data->>'establishmentId' != '1502162'`)
+      .whereRaw(`(data->>'establishmentId' != '1502162' or data->>'establishmentId' is null)`)
       .where('cases.updated_at', '>', params.since || '2019-07-01')
       .groupBy('cases.id');
   };


### PR DESCRIPTION
The previous query asserting it was not equal to a string would ignore tasks without establishment ids (e.g. profile updates) for reasons.