### PR TITLE
Use "returned-to-applicant" to count iterations

### DIFF
--- a/lib/reports/tasks/index.js
+++ b/lib/reports/tasks/index.js
@@ -25,7 +25,7 @@ module.exports = ({ db, query: params, flow }) => {
       action = isAmendment ? 'amendment' : 'application';
     }
 
-    const iterations = record.activity.filter(e => e.match(/^status:(.)*:resubmitted$/)).length + 1;
+    const iterations = record.activity.filter(e => e.match(/^status:(.)*:returned-to-applicant$/)).length + 1;
     const updatedAt = record.updated_at;
 
     return { model, action, schemaVersion, iterations, updatedAt };


### PR DESCRIPTION
The values are very similar (and not necessarily accurate in either case) to "resubmitted", but for consistency with the old workflow metrics, continue to use returns as the PPL iteration counter.