### PR TITLE
Filter out deleted records from licence counts

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -26,6 +26,7 @@ module.exports = (settings) => {
             return req.db.asl(type)
               .count()
               .where({ status: 'active' })
+              .whereNull('deleted')
               .then(result => parseInt(result[0].count, 10));
           });
         return Promise.all(queries);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,9 +2984,9 @@
       "integrity": "sha512-Oo+0+CN9d2z6FToQW6Hwvi9ez09Y/usKwr0tsDsyg43a871zVJCi1nR0v03djLbRNcaCKjtrnVf2XJhTxEpPCg=="
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",


### PR DESCRIPTION
Legacy stub PPLs are created as active but can be deleted, so there are some records in the database which show as active but have been deleted, which is impossible for a "normal" licence.