### PR TITLE
Protect against null activity

### DIFF
--- a/lib/reports/tasks/index.js
+++ b/lib/reports/tasks/index.js
@@ -25,7 +25,7 @@ module.exports = ({ db, query: params, flow }) => {
       action = isAmendment ? 'amendment' : 'application';
     }
 
-    const iterations = record.activity.filter(e => e.match(/^status:(.)*:returned-to-applicant$/)).length + 1;
+    const iterations = record.activity.filter(e => e && e.match(/^status:(.)*:returned-to-applicant$/)).length + 1;
     const updatedAt = record.updated_at;
     const createdAt = record.created_at;
     const establishmentId = get(record, 'data.establishmentId');


### PR DESCRIPTION
Some of the workflow task seeds don't have any activity, and I don't have the desire to fix them.

This stops a task with no activity from blowing up the metrics page.