### PR TITLE
Fix exempt deadline query

### DIFF
--- a/lib/reports/ppl-sla/index.js
+++ b/lib/reports/ppl-sla/index.js
@@ -12,7 +12,7 @@ module.exports = ({ db, query: params, flow }) => {
   const query = () => {
     return db.flow('cases')
       .whereRaw(`(cases.data->>'deadlinePassed')::boolean = true`)
-      .whereRaw(`(cases.data->'deadline'->'exemption'->>'isExempt')::boolean != true`)
+      .whereRaw(`cases.data->'deadline'->'exemption'->>'isExempt' is null`)
       .whereRaw(`cases.data->>'model' = 'project'`)
       .whereRaw(`cases.data->>'action' = 'grant'`)
       .whereRaw(`cases.data->'modelData'->>'status' = 'inactive'`)


### PR DESCRIPTION
This was filtering out all expired deadline tasks before. Now it only filters out those where `isExempt` is set.