### PR TITLE
Exclude deleted projects from PPL counts

### DIFF
--- a/lib/reports/establishments/index.js
+++ b/lib/reports/establishments/index.js
@@ -60,13 +60,13 @@ module.exports = ({ db }) => {
   const parse = establishment => {
     const activePpls = db.asl('projects')
       .count('*')
-      .where({ establishment_id: establishment.id, status: 'active' })
+      .where({ establishment_id: establishment.id, status: 'active', deleted: null })
       .then(activePplCount => parseInt(activePplCount[0].count, 10));
 
     // submitted draft ppls: has at least one submitted version
     const submittedDrafts = db.asl('projects')
       .count('*')
-      .where({ establishment_id: establishment.id, status: 'inactive' })
+      .where({ establishment_id: establishment.id, status: 'inactive', deleted: null })
       .whereExists(builder => {
         builder.select('id')
           .from('project_versions')
@@ -78,7 +78,7 @@ module.exports = ({ db }) => {
     // unsubmitted draft ppls: has no submitted versions
     const unsubmittedDrafts = db.asl('projects')
       .count('*')
-      .where({ establishment_id: establishment.id, status: 'inactive' })
+      .where({ establishment_id: establishment.id, status: 'inactive', deleted: null })
       .whereNotExists(builder => {
         builder.select('id')
           .from('project_versions')


### PR DESCRIPTION
If an ASRU user creates a legacy licence conversion it is created with a status of `active` but can be deleted while still having a status of `active`. This means that the active licence counts for some establishments in this report are showing as incorrect.