### PR TITLE
Make upper date filter on reports inclusive

### DIFF
--- a/lib/reports/ppl-sla/index.js
+++ b/lib/reports/ppl-sla/index.js
@@ -24,7 +24,7 @@ module.exports = ({ db, query: params, flow }) => {
             this.whereRaw(`(cases.data->>'deadlinePassedDate')::date > '${start}'`);
           }
           if (end) {
-            this.whereRaw(`(cases.data->>'deadlinePassedDate')::date < '${end}'`);
+            this.whereRaw(`(cases.data->>'deadlinePassedDate')::date <= '${end}'`);
           }
         }
       });

--- a/lib/reports/tasks/index.js
+++ b/lib/reports/tasks/index.js
@@ -12,7 +12,7 @@ module.exports = ({ db, query: params, flow }) => {
       .where({ status: 'resolved' })
       .whereRaw(`(data->>'establishmentId' != '1502162' or data->>'establishmentId' is null)`)
       .where('cases.updated_at', '>', params.start || '2019-07-01')
-      .where('cases.updated_at', '<', params.end || (new Date()).toISOString())
+      .where('cases.updated_at', '<', `${params.end}T23:59:59.999Z` || (new Date()).toISOString())
       .groupBy('cases.id');
 
     if (params.establishment) {


### PR DESCRIPTION
Tasks processed and deadlines passed on a particular date should be included when that date is used as the end date for the date filtering.