### PR TITLE
Fix PPL application report time distributions

### DIFF
--- a/lib/reports/ppl-applications/index.js
+++ b/lib/reports/ppl-applications/index.js
@@ -5,13 +5,9 @@ const moment = require('moment-business-time');
 moment.updateLocale('en', { holidays: bankHolidays });
 
 const formatTime = time => {
-  const minute = 60 * 1000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
-  const days = Math.floor(time / day);
-  const hours = Math.floor((time % day) / hour);
-  const minutes = Math.floor((time % hour) / minute);
-  return `${days}d${hours}h${minutes}m`;
+  const day = 24 * 60 * 60 * 1000;
+  const days = Math.round(time / day);
+  return days;
 };
 
 module.exports = ({ db, query: params, flow }) => {
@@ -72,6 +68,9 @@ module.exports = ({ db, query: params, flow }) => {
       .first()
       .then(project => {
         const draftingTime = project.created_at ? moment(record.created_at).diff(project.created_at) : 0;
+
+        timers.total += draftingTime;
+        timers.establishment += draftingTime;
 
         return {
           title: project.title,


### PR DESCRIPTION
Include drafting time in total time and time with establishment.

Some applications were still being reported as 100% with ASRU, and 0% with establishment because the drafting time was not being considered.

Remove sub-day output from timers because it doesn't convert naturally in Excel.