### PR TITLE
Only list most recent PPL version in PPL details report

### DIFF
--- a/lib/reports/ppl-details/index.js
+++ b/lib/reports/ppl-details/index.js
@@ -17,6 +17,7 @@ module.exports = ({ db }) => {
           .whereNull('deleted')
           .groupBy('project_versions.project_id', 'project_versions.id') // group by limits results to 1 per project
           .orderBy('project_versions.updated_at', 'desc')
+          .first()
           .as('version'),
         'projects.id',
         'version.project_id'


### PR DESCRIPTION
Where a PPL has been amended a row is added per version. Add a `.first()` to the version query to ensure only the latest granted version is listed.