### PR TITLE
Select version properties as subquery instead of join

### DIFF
--- a/lib/reports/ppl-details/parse.js
+++ b/lib/reports/ppl-details/parse.js
@@ -16,28 +16,28 @@ const yesOrNo = (project, path, options = {}) => {
 
 const isLegacy = project => project.schema_version === 0 ? 'yes' : 'no';
 
-const hasAutoRA = project => yesOrNo(project, 'version.ra_compulsory');
+const hasAutoRA = project => yesOrNo(project, 'ra_compulsory');
 
 const hasInspectorRA = project => {
-  const raCompulsory = get(project, 'version.ra_compulsory', false);
-  const retrospectiveAssessment = get(project, 'version.data.retrospectiveAssessment', false);
-  return !raCompulsory && retrospectiveAssessment;
+  const raCompulsory = get(project, 'ra_compulsory', false);
+  const retrospectiveAssessment = get(project, 'data.retrospectiveAssessment', false);
+  return (!raCompulsory && retrospectiveAssessment) ? 'yes' : 'no';
 };
 
 const getSpeciesList = project => (get(project, 'species') || []).join(', ');
 
-const getAdditionalAvailabilityCount = project => (get(project, 'version.data.establishments') || []).length;
+const getAdditionalAvailabilityCount = project => (get(project, 'data.establishments') || []).length;
 
 const getPolesCount = project => {
-  return project.schema_version === 0 ? 'unknown' : (get(project, 'version.data.polesList') || []).length;
+  return project.schema_version === 0 ? 'unknown' : (get(project, 'data.polesList') || []).length;
 };
 
-const getProtocolCount = project => (get(project, 'version.data.protocols') || []).length;
+const getProtocolCount = project => (get(project, 'data.protocols') || []).length;
 
 const getHighestSeverity = project => {
   let severities = ['unknown', 'mild', 'moderate', 'severe', 'non-recovery'];
 
-  return (get(project, 'version.data.protocols') || []).reduce((highestSeverity, protocol) => {
+  return (get(project, 'data.protocols') || []).reduce((highestSeverity, protocol) => {
     if (protocol.severity) {
       const protocolSeverity = protocol.severity.toLowerCase();
       if (severities.indexOf(protocolSeverity) > severities.indexOf(highestSeverity)) {
@@ -49,15 +49,15 @@ const getHighestSeverity = project => {
 };
 
 const useOfNMBA = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.nmbas-used');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.nmbas-used');
 };
 
 const useOfNonPurposeBredAnimals = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.purpose-bred', { invert: true });
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.purpose-bred', { invert: true });
 };
 
 const useOfGAAnimals = project => {
-  const protocols = (get(project, 'version.data.protocols') || []);
+  const protocols = (get(project, 'data.protocols') || []);
   if (project.schema_version === 0) {
     return protocols.some(protocol => {
       return (get(protocol, 'species') || []).some(s => s['genetically-altered']);
@@ -67,58 +67,58 @@ const useOfGAAnimals = project => {
 };
 
 const useOfEndangeredAnimals = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.endangered-animals');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.endangered-animals');
 };
 
 const useOfWildAnimals = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.wild-animals');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.wild-animals');
 };
 
 const useOfFeralAnimals = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.feral-animals');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.feral-animals');
 };
 
 const useOfCommercialSlaughter = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.commercial-slaughter');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.commercial-slaughter');
 };
 
 const useOfHumanMaterial = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.animals-containing-human-material');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.animals-containing-human-material');
 };
 
 const useOfBothSexes = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.experimental-design-sexes');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.experimental-design-sexes');
 };
 
 const translationalResearch = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.funding-basic-translational');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.funding-basic-translational');
 };
 
 const dataForRegAuthorities = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.scientific-background-producing-data');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.scientific-background-producing-data');
 };
 
 const serviceToOthers = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.scientific-background-producing-data-service');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.scientific-background-producing-data-service');
 };
 
 const nonRegTesting = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.scientific-background-non-regulatory');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.scientific-background-non-regulatory');
 };
 
 const productionOfGAAnimals = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.scientific-background-genetically-altered');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.scientific-background-genetically-altered');
 };
 
 const manufactureOfMedicines = project => {
-  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'version.data.scientific-background-vaccines');
+  return project.schema_version === 0 ? 'unknown' : yesOrNo(project, 'data.scientific-background-vaccines');
 };
 
 const isContinuation = project => {
   if (project.schema_version === 0) {
-    return yesOrNo(project, 'version.data.continuation');
+    return yesOrNo(project, 'data.continuation');
   }
-  return get(project, 'version.data.project-continuation', []).length > 0 ? 'yes' : 'no';
+  return get(project, 'data.project-continuation', []).length > 0 ? 'yes' : 'no';
 };
 
 const parse = project => {


### PR DESCRIPTION
I think the previous way was joining against a table with only one record, which looked ok against seed data because it reflected the most recent change and most versions are null anyway.

This way matches the way that associated version data is loaded for the PPL list report. and is definitely loading unique data against seeds.