### PR TITLE
Fix PPL application report

### DIFF
--- a/lib/reports/ppl-applications/index.js
+++ b/lib/reports/ppl-applications/index.js
@@ -28,7 +28,10 @@ module.exports = ({ db, query: params, flow }) => {
   };
 
   const parse = record => {
-    const activity = record.activity.filter(a => a.event_name.match(/^status:/));
+    const activity = record.activity
+      .filter(a => a.event_name.match(/^status:/))
+      .sort((a, b) => a.created_at < b.created_at ? -1 : 1); // ascending time order
+
     const timers = {
       total: 0,
       asru: 0,
@@ -52,7 +55,7 @@ module.exports = ({ db, query: params, flow }) => {
         timers.licensing += diff;
       }
       timers.total += diff;
-      last = moment(record.created_at).valueOf();
+      last = moment(log.created_at).valueOf();
     });
 
     return db.asl('projects')


### PR DESCRIPTION
We weren't correctly updating the previous activity time when iterating through PPL application activity so the numbers were coming back incorrect.

Also add a sort to remove dependency on database return order.