### PR TITLE
Filter out null protocols

### DIFF
--- a/lib/reports/ppl-details/parse.js
+++ b/lib/reports/ppl-details/parse.js
@@ -32,12 +32,12 @@ const getPolesCount = project => {
   return project.schema_version === 0 ? 'unknown' : (get(project, 'data.polesList') || []).length;
 };
 
-const getProtocolCount = project => (get(project, 'data.protocols') || []).length;
+const getProtocolCount = project => (get(project, 'data.protocols') || []).filter(Boolean).length;
 
 const getHighestSeverity = project => {
   let severities = ['unknown', 'mild', 'moderate', 'severe', 'non-recovery'];
 
-  return (get(project, 'data.protocols') || []).reduce((highestSeverity, protocol) => {
+  return (get(project, 'data.protocols') || []).filter(Boolean).reduce((highestSeverity, protocol) => {
     if (protocol.severity) {
       const protocolSeverity = protocol.severity.toLowerCase();
       if (severities.indexOf(protocolSeverity) > severities.indexOf(highestSeverity)) {
@@ -57,7 +57,7 @@ const useOfNonPurposeBredAnimals = project => {
 };
 
 const useOfGAAnimals = project => {
-  const protocols = (get(project, 'data.protocols') || []);
+  const protocols = (get(project, 'data.protocols') || []).filter(Boolean);
   if (project.schema_version === 0) {
     return protocols.some(protocol => {
       return (get(protocol, 'species') || []).some(s => s['genetically-altered']);


### PR DESCRIPTION
Some of these exist on preprod and cause the report to fail with an error.