### PR TITLE
Remove PPLs which had their issue date changed to pre-aspel date from PPL applications report

### DIFF
--- a/lib/reports/ppl-applications/index.js
+++ b/lib/reports/ppl-applications/index.js
@@ -68,10 +68,11 @@ module.exports = ({ db, query: params, flow }) => {
       .leftJoin('establishments', 'projects.establishment_id', 'establishments.id')
       .leftJoin('profiles', 'projects.licence_holder_id', 'profiles.id')
       .where({ 'projects.id': record.data.id })
+      .where('projects.issue_date', '>', '2019-07-31')
       .first()
       .then(project => {
-        if (moment(project.issue_date).isBefore('2019-08-01')) {
-          // ignore PPLs which have had their issue date changed to pre-aspel
+        // ignore PPLs which have had their issue date changed to pre-aspel
+        if (!project) {
           return [];
         }
         const draftingTime = project.created_at ? moment(record.created_at).diff(project.created_at) : 0;

--- a/lib/reports/ppl-applications/index.js
+++ b/lib/reports/ppl-applications/index.js
@@ -70,6 +70,10 @@ module.exports = ({ db, query: params, flow }) => {
       .where({ 'projects.id': record.data.id })
       .first()
       .then(project => {
+        if (moment(project.issue_date).isBefore('2019-08-01')) {
+          // ignore PPLs which have had their issue date changed to pre-aspel
+          return [];
+        }
         const draftingTime = project.created_at ? moment(record.created_at).diff(project.created_at) : 0;
 
         timers.total += draftingTime;

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "9.8.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.8.0.tgz",
-      "integrity": "sha1-xowghvaLyt0vDMV+ghY/axAfEH4=",
+      "version": "9.9.3",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.9.3.tgz",
+      "integrity": "sha1-QNDl8XvX+sWXAR1oDoPmjfogXQY=",
       "dev": true,
       "requires": {
         "@asl/constants": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "@asl/schema": "^9.8.0",
+    "@asl/schema": "^9.9.3",
     "@ukhomeoffice/taskflow": "^2.2.2",
     "dotenv": "^8.2.0",
     "eslint": "^7.2.0",

--- a/test/integration/ppl-applications/index.js
+++ b/test/integration/ppl-applications/index.js
@@ -92,6 +92,7 @@ describe('PPL Applications Report', () => {
           title: 'Active Project',
           status: 'active',
           licence_number: 'P1234',
+          issue_date: '2020-01-26T12:00:00.000',
           created_at: '2020-01-01T12:00:00.000'
         },
         {


### PR DESCRIPTION
These represent a small number of converted paper licences that were not added using the dedicated functionality. They end up showing really weird data in the report because the issue date is before the application was submitted.

Since this is confusing for people consuming the report, and there are only a couple, remove them from the report completely.