### PR TITLE
Don't push null values to stream reports

### DIFF
--- a/lib/reports/index.js
+++ b/lib/reports/index.js
@@ -33,8 +33,8 @@ const step = fn => {
       .then(() => fn(record))
       .then(result => {
         if (Array.isArray(result)) {
-          result.forEach(r => this.push(r));
-        } else {
+          result.forEach(r => r && this.push(r));
+        } else if (result) {
           this.push(result);
         }
       })


### PR DESCRIPTION
Pushing null to a stream terminates the stream, so instead do not push a value at all if a streaming report returns a null row.