### PR TITLE
Fix `isApplication` definition in actioned tasks report

### DIFF
--- a/lib/reports/actioned-tasks/get-task-type.js
+++ b/lib/reports/actioned-tasks/get-task-type.js
@@ -3,7 +3,7 @@ const { get } = require('lodash');
 module.exports = task => {
   const model = get(task, 'data.model');
   const action = get(task, 'data.action');
-  const isApplication = get(task, 'data.modelData.status') === 'inactive';
+  const isApplication = get(task, 'data.modelData.status') !== 'active';
 
   switch (model) {
     case 'establishment':


### PR DESCRIPTION
It was being used for PILs and PPLs, but inactive PILs have a status of `pending` so all PIL application tasks were being wrongly marked as amendments.

Check that status is not `active` instead.