### PR TITLE
Add query to ASRU workload to count returned task events

### DIFF
--- a/lib/routers/asru-workload/get-workload.js
+++ b/lib/routers/asru-workload/get-workload.js
@@ -54,7 +54,20 @@ module.exports = async ({ db, flow, progress, withAsru, start, end }) => {
           moment(start).startOf('day').toISOString(),
           moment(end).endOf('day').toISOString()
         ]);
-    } else {
+    } else if (progress === 'returned') {
+      query = db.flow('activity_log')
+        .select([
+          'changed_by AS assigned_to',
+          db.flow.raw(`event->'data'->>'model' AS model`),
+          db.flow.raw(`event->'data'->'modelData'->>'status' AS model_status`)
+        ])
+        .where('event_name', '~', `:returned-to-applicant$`)
+        .orderBy('updated_at')
+        .whereBetween('updated_at', [
+          moment(start).startOf('day').toISOString(),
+          moment(end).endOf('day').toISOString()
+        ]);
+    } else if (progress === 'open') {
       query = db.flow('cases')
         .select([
           'id',


### PR DESCRIPTION
Find all returned to applicant events from the activity log between the dates provided.