### PR TITLE
Include `update` events in internal deadline checks

### DIFF
--- a/lib/reports/internal-deadlines/index.js
+++ b/lib/reports/internal-deadlines/index.js
@@ -64,7 +64,7 @@ module.exports = ({ db, query: params }) => {
     let extended;
 
     record.activity
-      .filter(a => a.event_name.match(/^status:/)) // ignore everything except status changes
+      .filter(a => a.event_name.match(/^status:/) || a.event_name === 'update')
       .sort((a, b) => a.created_at < b.created_at ? -1 : 1) // ascending time order
       .forEach(activity => {
         if (!target) {


### PR DESCRIPTION
The deadline is set in an `update` event _after_ the task is sent to an inspector, so in most cases of expired deadlines the deadline will only be present in the data in the most recent `update` event and not in any of the preceding status changes.